### PR TITLE
Completed Using a HashSet to Mark Occupied Tiles

### DIFF
--- a/scenes/Main.cs
+++ b/scenes/Main.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using System.Collections.Generic;
 
 namespace Game;
 
@@ -10,6 +11,7 @@ public partial class Main : Node2D
 	private Button placeBuildingButton;
 	private TileMapLayer highlightTileMapLayer;
 	private Vector2? hoveredGridCell;
+	private HashSet<Vector2> occupiedCells = new();
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
@@ -26,7 +28,7 @@ public partial class Main : Node2D
 
 	public override void _UnhandledInput(InputEvent evt)
 	{
-		if (cursor.Visible && evt.IsActionPressed("left_click"))
+		if (cursor.Visible && evt.IsActionPressed("left_click") && !occupiedCells.Contains(GetMouseGridCellPosition()))
 		{
 			PlaceBuildingAtMousePosition();
 			cursor.Visible = false;
@@ -60,6 +62,7 @@ public partial class Main : Node2D
 
 		var gridPosition = GetMouseGridCellPosition();
 		building.GlobalPosition = gridPosition * 64;
+		occupiedCells.Add(gridPosition);
 
 		hoveredGridCell = null;
 		UpdateHighlightTileMapLayer();


### PR DESCRIPTION
Added in a hashset for occupied tiles and added the tile to it whenever a building is placed. Also added checks for whenever a building is put on top of an occupied tile.