### PR TITLE
Completed Using Autoloads and Custom Signals for Grid State Updating

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.3", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
+[autoload]
+
+GameEvents="*res://scenes/autoload/GameEvents.tscn"
+
 [display]
 
 window/size/viewport_width=1280

--- a/scenes/autoload/GameEvents.cs
+++ b/scenes/autoload/GameEvents.cs
@@ -1,0 +1,25 @@
+using Game.Component;
+using Godot;
+
+namespace Game.Autoload;
+
+public partial class GameEvents : Node
+{
+	public static GameEvents Instance { get; private set;}
+
+	[Signal]
+	public delegate void BuildingPlacedEventHandler(BuildingComponent buildingComponent);
+
+    public override void _Notification(int what)
+    {
+        if (what == NotificationSceneInstantiated)
+		{
+			Instance = this;
+		}
+    }
+
+	public static void EmitBuildingPlaced(BuildingComponent buildingComponent)
+	{
+		Instance.EmitSignal(SignalName.BuildingPlaced, buildingComponent);
+	}
+}

--- a/scenes/autoload/GameEvents.tscn
+++ b/scenes/autoload/GameEvents.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://d3rt0k1rwpmna"]
+
+[ext_resource type="Script" path="res://scenes/autoload/GameEvents.cs" id="1_aqicq"]
+
+[node name="GameEvents" type="Node"]
+script = ExtResource("1_aqicq")

--- a/scenes/component/BuildingComponent.cs
+++ b/scenes/component/BuildingComponent.cs
@@ -1,3 +1,4 @@
+using Game.Autoload;
 using Godot;
 
 namespace Game.Component;
@@ -10,6 +11,7 @@ public partial class BuildingComponent : Node2D
 	public override void _Ready()
 	{
 		AddToGroup(nameof(BuildingComponent));
+		GameEvents.EmitBuildingPlaced(this);
 	}
 
 	public Vector2I GetGridCellPosition()

--- a/scenes/manager/GridManager.cs
+++ b/scenes/manager/GridManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Game.Autoload;
 using Game.Component;
 using Godot;
 
@@ -14,7 +15,12 @@ public partial class GridManager : Node
 	[Export]
 	private TileMapLayer baseTerrainTileMapLayer;
 
-	public bool IsTilePositionValid(Vector2I tilePosition)
+    public override void _Ready()
+    {
+        GameEvents.Instance.BuildingPlaced += OnBuildingPlaced;
+    }
+
+    public bool IsTilePositionValid(Vector2I tilePosition)
 	{
 		var customData = baseTerrainTileMapLayer.GetCellTileData(tilePosition);
 		if (customData == null) return false;
@@ -62,5 +68,10 @@ public partial class GridManager : Node
 				highlightTileMapLayer.SetCell(tilePosition, 0, Vector2I.Zero);
 			}
 		}
+	}
+
+	private void OnBuildingPlaced(BuildingComponent buildingComponent)
+	{
+		MarkTileAsOccupied(buildingComponent.GetGridCellPosition());
 	}
 }


### PR DESCRIPTION
Added a 'GameEvents' autoload node and created a custom signal through it that demarcates when a building is placed so that its tile can be marked as occupied, preventing future buildings from being placed there.